### PR TITLE
feat: adding GovDao, Dao, Laws, and Amendments sections

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -40,7 +40,7 @@ GovDAO membership is public information. All GovDAO members will have to have th
 
 Constraints to the powers of the GovDAO must be explicitly defined in Article 3: Citizen Rights, Responsibilities, and GNOTDAO or through the constitutional amendment process outlined in Article 5: Amendments.
 
-GovDAO has the power to create and dissolve Sub-DAOs, but the creation process of any Sub-DAO must adhere to the rules outlines Article 2: DAOs and Sub-DAOs.
+GovDAO has the power to create and dissolve Sub-DAOs. The creation process of any Sub-DAO must adhere to the rules outlines Article 2: DAOs and Sub-DAOs.
 
 ## Article 2: DAOs and Sub-DAOs
 


### PR DESCRIPTION
This is a big jump, but its a culmination of research and feedback I've gotten from folks. 

Primary philosophy here: less is more

There are several types of changes here:

- CLEANUPS - just removing TODOS and notes, since we can handle these in our Issue tracker. This is mostly to make it easier to read and remove notes that are not needed. I also removed sections that are not needed for now (we can always add them back later)
- GovDAO and DAO descriptions. I ported over what made sense for AtomOne and put in some wording specific to us (I also combined some of the work that @Kouteki had put into place). The major effort here is to put high level guidance, but to give the flexibility for the GovDAO Charter and Bylaws to define most of the details. The DAO constraints in ATOMONE are really nice, so I've pulled those in as well. NOTE: I added a section on Arbitration and conflict resolution that I think is important. Basically, if a Sub-DAO can't resolve an issue internally, an appeal can be made to a Parent DAO, and this appeals process can continue recursively up to the GovDAO, which will make a binding decision on the issue. This is an important way to address "dead locks" in governance, and is very important from my research.
- LAWS and AMENDMENTS. I kept these separate because they played different roles. 