### PR TITLE
feat: removing TODO section in CONSTITUTION and updating README for clarity

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -223,9 +223,7 @@ All updates to gno.land must be proposed as distinct, independent components. Ea
 
 Adequate time must be provided between the consideration of each proposal to allow for comprehensive review and community input. The minimum duration for discussion and voting on each proposal shall be two weeks.
 
-The passing of Software Update Proposals shall require the passage of law.
-
-[TODO: name stakeholders from governance structure] are responsible and may be held accountable for voting YES only on software update proposals that make correct changes toward the living constitution and laws (any substantial changes to the software must first be reflected in the constitution and laws). This responsibility exists independently of the Oversight DAOs’ regulatory function.
+The passing of Software Update Proposals shall require the passage of law by the GovDAO.
 
 ## Article 5: Amendments
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 **Disclaimer:** This repository is a work in progress (WIP) and subject to ongoing updates.  
 
-This repo defines the genesis of **gno.land**, including its Constitution, governance rules, and smart contracts for the **GovDAO**, the entity managing gno.land. It aims to establish the foundation for a sustainable, decentralized platform.
+This repo defines the genesis of **gno.land**, including its Constitution and governance rules for GovDAO, the entity managing gno.land. It aims to establish the foundation for a sustainable, decentralized platform.
 
-## Contributing  
+## Contributing
+
 We invite you to participate by opening issues or submitting pull requests for discussions and improvements. Your feedback is essential to shaping the future of gno.land.
 
 Our current focus is on drafting our [Constitution](https://github.com/gnolang/genesis/blob/main/CONSTITUTION.md), which is an important part of our upcoming Beta Launch in our [road to mainnet](https://gno.land/r/gnoland/blog:p/road-to-mainnet).


### PR DESCRIPTION
# NOTES

Two small updates.
- Update to constitution to remove TODO item with confusing wording. Simplified for clarity
- Update the readme to remove wording about GOVDAO smart contract, since that now lives on Portal Loop as a release candidate.